### PR TITLE
Update teleop.py

### DIFF
--- a/diablo_interaction/diablo_teleop/diablo_teleop/teleop.py
+++ b/diablo_interaction/diablo_teleop/diablo_teleop/teleop.py
@@ -129,6 +129,9 @@ def main(args=None):
             elif key == 'c':
                 generMsgs(mode_mark=True,jump_mode=True)
                 teleop_cmd.publish(ctrlMsgs)
+            elif key == 't':
+                generMsgs(mode_mark=True,jump_mode=False)
+                teleop_cmd.publish(ctrlMsgs)
             elif key == 'f':
                 generMsgs(mode_mark=True,dance_mode=True)
                 teleop_cmd.publish(ctrlMsgs)


### PR DESCRIPTION
按键盘控制中，按下“跳跃”模式，机器人一直处于半蹲蓄力状态，并不会释放，因此，增加jump_mode=False；逻辑